### PR TITLE
added functionality to switch embedding model to ollama hosted embedding model

### DIFF
--- a/app.py
+++ b/app.py
@@ -64,6 +64,7 @@ def create_answer(prompt):
             model,
             prompt,
             query_config,
+            use_rag=use_rag,
             chat_history=st.session_state.messages,
         )
 
@@ -168,7 +169,7 @@ with st.sidebar:
     top_p = st.select_slider(
         "Top P", options=[round(0.1 * i, 1) for i in range(0, 10)], value=0.2
     )
-
+    use_rag = st.checkbox('Enable RAG (Retrieval-Augmented Generation)')
     top_k = st.slider("Top K", 0, 20, 1)
 
     moderationfilter = st.checkbox("Moderation Filter")
@@ -181,29 +182,44 @@ with st.sidebar:
         # Dropdown for embedding models
         embedding_option = st.selectbox(
             "Choose embedding model:",
-            ("Hugging Face", "Ollama")
+            ("Hugging Face", "mxbai-embed-large:latest")
         )
 
-        # Update the embedding model in session state based on user selection
-        if embedding_option == "Hugging Face":
-            st.session_state.databroker.set_embedding_model("huggingface")
-        elif embedding_option == "Ollama":
-            st.session_state.databroker.set_embedding_model("ollama")
-        
-        # Buttons inside the expander
-        clear_db = st.button("Clear DB")
-        generate_embeddings = st.button("Generate Embeddings")
+        # Check if embedding model has changed
+        if 'selected_embedding_model' not in st.session_state:
+            st.session_state.selected_embedding_model = embedding_option
 
-        # Feedback based on button press
-        if clear_db:
-            st.session_state.databroker.clear_db()  # Call the clear_db method from the session state
-            st.sidebar.success("Database cleared!")
-        
-        if generate_embeddings:
-            # Retrieve the current embedding model from the session state
-            current_embedding_model = st.session_state.databroker.get_embedding_model()
-            st.sidebar.info(f"Generating embeddings using {current_embedding_model}...")
+        if embedding_option != st.session_state.selected_embedding_model:
+            # Update the session state with the new model
+            st.session_state.selected_embedding_model = embedding_option
+
+            # Update the embedding model in databroker
+            if embedding_option == "Hugging Face":
+                st.session_state.databroker.set_embedding_model("huggingface")
+            elif embedding_option == "mxbai-embed-large:latest":
+                st.session_state.databroker.set_embedding_model("mxbai-embed-large:latest")
+
+            try:
+                st.session_state.databroker.clear_db()
+            except Exception as e:
+                st.sidebar.warning(f"Could not clear the database: {e}")
             st.session_state.databroker.ingest_and_process_data()
+            st.sidebar.success(f"Database cleared and embeddings regenerated using {embedding_option}!")
+        ##Removed these buttons but they could be useful in the future for more granual control over what's happening to our DB
+        # # # Buttons inside the expander
+        # clear_db = st.button("Clear DB")
+        # generate_embeddings = st.button("Generate Embeddings")
+
+        # # Feedback based on button press
+        # if clear_db:
+        #     st.session_state.databroker.clear_db()  # Call the clear_db method from the session state
+        #     st.sidebar.success("Database cleared!")
+        
+        # if generate_embeddings:
+        #     # Retrieve the current embedding model from the session state
+        #     current_embedding_model = st.session_state.databroker.get_embedding_model()
+        #     st.sidebar.info(f"Generating embeddings using {current_embedding_model}...")
+        #     st.session_state.databroker.ingest_and_process_data()
 
 chat_tab, survey_tab = st.tabs(["Chat", "Survey"])
 with survey_tab:

--- a/app.py
+++ b/app.py
@@ -169,24 +169,22 @@ with st.sidebar:
     top_p = st.select_slider(
         "Top P", options=[round(0.1 * i, 1) for i in range(0, 10)], value=0.2
     )
-    use_rag = st.checkbox('Enable RAG (Retrieval-Augmented Generation)')
+    use_rag = st.checkbox("Enable RAG (Retrieval-Augmented Generation)")
     top_k = st.slider("Top K", 0, 20, 1)
 
     moderationfilter = st.checkbox("Moderation Filter")
     onlyusecontext = st.checkbox("Only Use Knowledge Base")
-
 
     st.sidebar.markdown("---")  # Horizontal line
     # Create an expandable section for advanced options
     with st.sidebar.expander("Advanced DataBase Options", expanded=False):
         # Dropdown for embedding models
         embedding_option = st.selectbox(
-            "Choose embedding model:",
-            ("Hugging Face", "mxbai-embed-large:latest")
+            "Choose embedding model:", ("Hugging Face", "mxbai-embed-large:latest")
         )
 
         # Check if embedding model has changed
-        if 'selected_embedding_model' not in st.session_state:
+        if "selected_embedding_model" not in st.session_state:
             st.session_state.selected_embedding_model = embedding_option
 
         if embedding_option != st.session_state.selected_embedding_model:
@@ -197,14 +195,18 @@ with st.sidebar:
             if embedding_option == "Hugging Face":
                 st.session_state.databroker.set_embedding_model("huggingface")
             elif embedding_option == "mxbai-embed-large:latest":
-                st.session_state.databroker.set_embedding_model("mxbai-embed-large:latest")
+                st.session_state.databroker.set_embedding_model(
+                    "mxbai-embed-large:latest"
+                )
 
             try:
                 st.session_state.databroker.clear_db()
             except Exception as e:
                 st.sidebar.warning(f"Could not clear the database: {e}")
             st.session_state.databroker.ingest_and_process_data()
-            st.sidebar.success(f"Database cleared and embeddings regenerated using {embedding_option}!")
+            st.sidebar.success(
+                f"Database cleared and embeddings regenerated using {embedding_option}!"
+            )
         ##Removed these buttons but they could be useful in the future for more granual control over what's happening to our DB
         # # # Buttons inside the expander
         # clear_db = st.button("Clear DB")
@@ -214,7 +216,7 @@ with st.sidebar:
         # if clear_db:
         #     st.session_state.databroker.clear_db()  # Call the clear_db method from the session state
         #     st.sidebar.success("Database cleared!")
-        
+
         # if generate_embeddings:
         #     # Retrieve the current embedding model from the session state
         #     current_embedding_model = st.session_state.databroker.get_embedding_model()

--- a/app.py
+++ b/app.py
@@ -175,6 +175,36 @@ with st.sidebar:
     onlyusecontext = st.checkbox("Only Use Knowledge Base")
 
 
+    st.sidebar.markdown("---")  # Horizontal line
+    # Create an expandable section for advanced options
+    with st.sidebar.expander("Advanced DataBase Options", expanded=False):
+        # Dropdown for embedding models
+        embedding_option = st.selectbox(
+            "Choose embedding model:",
+            ("Hugging Face", "Ollama")
+        )
+
+        # Update the embedding model in session state based on user selection
+        if embedding_option == "Hugging Face":
+            st.session_state.databroker.set_embedding_model("huggingface")
+        elif embedding_option == "Ollama":
+            st.session_state.databroker.set_embedding_model("ollama")
+        
+        # Buttons inside the expander
+        clear_db = st.button("Clear DB")
+        generate_embeddings = st.button("Generate Embeddings")
+
+        # Feedback based on button press
+        if clear_db:
+            st.session_state.databroker.clear_db()  # Call the clear_db method from the session state
+            st.sidebar.success("Database cleared!")
+        
+        if generate_embeddings:
+            # Retrieve the current embedding model from the session state
+            current_embedding_model = st.session_state.databroker.get_embedding_model()
+            st.sidebar.info(f"Generating embeddings using {current_embedding_model}...")
+            st.session_state.databroker.ingest_and_process_data()
+
 chat_tab, survey_tab = st.tabs(["Chat", "Survey"])
 with survey_tab:
     st.text("Please complete this short survey sharing your experiences with the team!")

--- a/src/ingestion/embedding.py
+++ b/src/ingestion/embedding.py
@@ -3,8 +3,9 @@ from dataclasses import dataclass
 from typing import List
 
 import numpy as np
-from langchain_huggingface.embeddings import HuggingFaceEmbeddings
 from langchain_community.embeddings.ollama import OllamaEmbeddings
+from langchain_huggingface.embeddings import HuggingFaceEmbeddings
+
 from .chunking import Chunk
 from .raw_data import Data
 

--- a/src/ingestion/embedding.py
+++ b/src/ingestion/embedding.py
@@ -85,7 +85,6 @@ class HuggingFaceSentenceTransformerEmbedder(Embedder):
         return embeddings
 
 
-
 class OllamaEmbedder(Embedder):
     """
     An embedder that uses API calls to our Ollama instances hosting embedding models to generate embeddings.
@@ -102,8 +101,7 @@ class OllamaEmbedder(Embedder):
 
         self.model_name = model_name  # Store the model name
         self.model = OllamaEmbeddings(
-        model=self.model_name,
-        base_url="http://macbook1.sciencegpt.ca:11434"
+            model=self.model_name, base_url="http://macbook1.sciencegpt.ca:11434"
         )
 
     def __call__(self, chunks: List[Chunk]) -> List[Embedding]:
@@ -116,8 +114,7 @@ class OllamaEmbedder(Embedder):
         Returns:
             List[Embedding]: A list of Embedding objects containing the embedded vectors and metadata.
         """
-        
-        
+
         embeddings = []
         for chunk in chunks:
             vector = self.model.embed_query(chunk.text)

--- a/src/ingestion/embedding.py
+++ b/src/ingestion/embedding.py
@@ -4,7 +4,7 @@ from typing import List
 
 import numpy as np
 from langchain_huggingface.embeddings import HuggingFaceEmbeddings
-
+from langchain_community.embeddings.ollama import OllamaEmbeddings
 from .chunking import Chunk
 from .raw_data import Data
 
@@ -72,6 +72,52 @@ class HuggingFaceSentenceTransformerEmbedder(Embedder):
         Returns:
             List[Embedding]: A list of Embedding objects containing the embedded vectors and metadata.
         """
+        embeddings = []
+        for chunk in chunks:
+            vector = self.model.embed_query(chunk.text)
+            embedding = Embedding(
+                name=chunk.name,
+                data_type=chunk.data_type,
+                vector=np.array(vector),
+                text=chunk.text,
+            )
+            embeddings.append(embedding)
+        return embeddings
+
+
+
+class OllamaEmbedder(Embedder):
+    """
+    An embedder that uses API calls to our Ollama instances hosting embedding models to generate embeddings.
+    """
+
+    def __init__(self, model_name: str):
+        """
+        Initialize the embedding API call for the embedding model on Ollama.
+
+        Args:
+            model_name (str): The name of the embedding model to use.
+                              Defaults to "mxbai-embed-large:latest".
+        """
+
+        self.model_name = model_name  # Store the model name
+        self.model = OllamaEmbeddings(
+        model=self.model_name,
+        base_url="http://macbook1.sciencegpt.ca:11434"
+        )
+
+    def __call__(self, chunks: List[Chunk]) -> List[Embedding]:
+        """
+        Embed a list of text chunks into vectors using the Ollama hosted embedding model
+
+        Args:
+            chunks (List[Chunk]): List of Chunk objects to be embedded.
+
+        Returns:
+            List[Embedding]: A list of Embedding objects containing the embedded vectors and metadata.
+        """
+        
+        
         embeddings = []
         for chunk in chunks:
             vector = self.model.embed_query(chunk.text)

--- a/src/orchestrator/chat_orchestrator.py
+++ b/src/orchestrator/chat_orchestrator.py
@@ -98,7 +98,13 @@ class ChatOrchestrator(metaclass=SingletonMeta):
         self.system_prompt = new_prompt
 
     def triage_query(
-        self, model: str, query: str, query_config, use_rag=False, chat_history=None, local=True
+        self,
+        model: str,
+        query: str,
+        query_config,
+        use_rag=False,
+        chat_history=None,
+        local=True,
     ) -> tuple[str, float]:
         """
         Given a user query, the orchestrator detects user intent and leverages
@@ -106,8 +112,8 @@ class ChatOrchestrator(metaclass=SingletonMeta):
 
         Returns the response text content (str) and cost (float)
         """
-        #print(f"Using model: {self.config.model_name}")
-        #print(self.config)
+        # print(f"Using model: {self.config.model_name}")
+        # print(self.config)
 
         print(query_config)
 
@@ -124,7 +130,7 @@ class ChatOrchestrator(metaclass=SingletonMeta):
         if query[:7].lower() == "search:":
             query = query[7:]
             prompt = ContextRetrieval(prompt, self.config)
-        
+
         if use_rag:
             prompt = ContextRetrieval(prompt, self.config)
 

--- a/src/orchestrator/chat_orchestrator.py
+++ b/src/orchestrator/chat_orchestrator.py
@@ -98,7 +98,7 @@ class ChatOrchestrator(metaclass=SingletonMeta):
         self.system_prompt = new_prompt
 
     def triage_query(
-        self, model: str, query: str, query_config, chat_history=None, local=True
+        self, model: str, query: str, query_config, use_rag=False, chat_history=None, local=True
     ) -> tuple[str, float]:
         """
         Given a user query, the orchestrator detects user intent and leverages
@@ -106,14 +106,15 @@ class ChatOrchestrator(metaclass=SingletonMeta):
 
         Returns the response text content (str) and cost (float)
         """
-        print(f"Using model: {self.config.model_name}")
-        print(self.config)
+        #print(f"Using model: {self.config.model_name}")
+        #print(self.config)
 
         print(query_config)
 
         # Set the model config and load the model
         self.set_model_config(query_config)
         self.load_model(model)
+        print(model)
 
         prompt = ConcretePrompt(self.system_prompt)
 
@@ -122,6 +123,9 @@ class ChatOrchestrator(metaclass=SingletonMeta):
         #  involving user input.
         if query[:7].lower() == "search:":
             query = query[7:]
+            prompt = ContextRetrieval(prompt, self.config)
+        
+        if use_rag:
             prompt = ContextRetrieval(prompt, self.config)
 
         # look for moderation filter

--- a/src/prompt/retrieval.py
+++ b/src/prompt/retrieval.py
@@ -47,14 +47,15 @@ class ContextRetrieval(PromptDecorator):
         print("Retrieval!\n", str(top_k))
         results = self.data_broker.search([query], top_k=top_k)
 
-
         #### If no results found, we should log and we should also tell the user that their RAG search did not return any results for some reason
         if not results or len(results[0]) == 0:
             # No results found; handle the case here
-            #logger.warning("No documents found for the query. Returning only the query as the prompt.")
-            print("no results returned... probably something wrong with the DB not existing but trying to be queried")
+            # logger.warning("No documents found for the query. Returning only the query as the prompt.")
+            print(
+                "no results returned... probably something wrong with the DB not existing but trying to be queried"
+            )
             return query  # Return the query itself if no context is found
-        
+
         print(results)
         context_text = "\n\n---\n\n".join([res.document for res in results[0]])
         return self._prompt.get_prompt(query).format(

--- a/src/prompt/retrieval.py
+++ b/src/prompt/retrieval.py
@@ -46,6 +46,15 @@ class ContextRetrieval(PromptDecorator):
             top_k = self.config.rag_params.top_k_retrieval
         print("Retrieval!\n", str(top_k))
         results = self.data_broker.search([query], top_k=top_k)
+
+
+        #### If no results found, we should log and we should also tell the user that their RAG search did not return any results for some reason
+        if not results or len(results[0]) == 0:
+            # No results found; handle the case here
+            #logger.warning("No documents found for the query. Returning only the query as the prompt.")
+            print("no results returned... probably something wrong with the DB not existing but trying to be queried")
+            return query  # Return the query itself if no context is found
+        
         print(results)
         context_text = "\n\n---\n\n".join([res.document for res in results[0]])
         return self._prompt.get_prompt(query).format(


### PR DESCRIPTION
Current functionality has local hugging face embeddings as default with option to switch to one embedding model on macbook. Upon selection, db is cleared and everything is reingested. embedding model is also used for query when rag is enabled.

added check box for RAG as well but kept search: functionality