### PR TITLE
Carter/query-rewriter

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -25,6 +25,9 @@ def init_streamlit():
     st.title("Science-GPT Prototype")
 
     if "config" not in st.session_state:
+
+        logger.set_user(st.session_state.get("name", "unknown"))
+
         st.session_state.config = load_config(
             config_name="system_config", config_dir=f"{os.getcwd()}/src/configs"
         )
@@ -152,7 +155,6 @@ def create_answer(prompt):
 
         logger.info(
             "Prompt: " + llm_prompt + " Response: " + response,
-            xtra={"user": st.session_state["name"]},
         )
 
         print(cost)

--- a/app/app.py
+++ b/app/app.py
@@ -286,7 +286,7 @@ def sidebar():
         st.session_state.use_rag = st.checkbox("Retrieval Augmented Generation")
         # Create an expandable section for advanced options
         if st.session_state.use_rag:
-            st.session_state.top_k = st.slider("Top K", 0, 20, 1)
+            st.session_state.top_k = st.slider("Top K", 0, 20, 5)
 
             with st.sidebar.expander("Advanced DataBase Options", expanded=False):
 

--- a/app/src/data_broker/data_broker.py
+++ b/app/src/data_broker/data_broker.py
@@ -172,14 +172,12 @@ class DataBroker(metaclass=SingletonMeta):
 
         existing_items = self.vector_store.collection.get(include=[])
         existing_ids = set(existing_items["ids"])
-        print(len(existing_ids))
 
         # Only add missing chunks
         new_chunks = []
         for chunk in chunks:
             if chunk.name not in existing_ids:
                 new_chunks.append(chunk)
-        print(len(new_chunks))
 
         # Choose embedder based on selected embedding model
         if len(new_chunks):

--- a/app/src/data_broker/data_broker.py
+++ b/app/src/data_broker/data_broker.py
@@ -72,6 +72,15 @@ class DataBroker(metaclass=SingletonMeta):
             self.embedder = OllamaEmbedder(
                 model_name=self.embedding_model, endpoint=macbook_endpoint
             )
+
+            try:
+                self.embedder.test_connection()
+            except RuntimeError as e:
+                logger.error(
+                    "Failed to connect to the Ollama model. Defaulting to HuggingFace embeddings."
+                )
+                self.embedder = HuggingFaceEmbedder(model_name="all-mpnet-base-v2")
+
         elif self.embedding_model in hface_models:
             self.embedder = HuggingFaceEmbedder(model_name=self.embedding_model)
 

--- a/app/src/ingestion/embedding.py
+++ b/app/src/ingestion/embedding.py
@@ -104,6 +104,13 @@ class OllamaEmbedder(Embedder):
         self.model_name = model_name  # Store the model name
         self.model = OllamaEmbeddings(model=self.model_name, base_url=endpoint)
 
+    def test_connection(self):
+        """(Carter) I've written this to test the connection to the macbook. We will default to Huggingface embeddings if this fails."""
+        try:
+            self.model.embed_query("test")
+        except Exception as e:
+            raise RuntimeError("Embedding model initialization failed") from e
+
     def __call__(self, chunks: List[Chunk]) -> List[Embedding]:
         """
         Embed a list of text chunks into vectors using the Ollama hosted embedding model

--- a/app/src/logs/logger.py
+++ b/app/src/logs/logger.py
@@ -32,7 +32,7 @@ class LogManager(logging.Logger, metaclass=SingletonMeta):
         """
         super().__init__(name, level)
         logging.addLevelName(SURVEY_LEVEL, "SURVEY")
-        self.extra_info = None
+        self.extra_info = {"user": "unknown"}
 
         # configure console logging
         handler = logging.StreamHandler()
@@ -58,12 +58,15 @@ class LogManager(logging.Logger, metaclass=SingletonMeta):
                 )
             )
 
+    def set_user(self, user: str):
+        self.extra_info["user"] = user
+
     def info(self, msg, *args, xtra=None, **kwargs):
-        extra_info = xtra if xtra is not None else self.extra_info
+        extra_info = self.extra_info | (xtra if xtra is not None else {})
         super().info(msg, *args, extra=extra_info, **kwargs)
 
     def survey(self, msg, *args, xtra=None, **kwargs):
-        extra_info = xtra if xtra is not None else self.extra_info
+        extra_info = self.extra_info | (xtra if xtra is not None else {})
         if self.isEnabledFor(SURVEY_LEVEL):
             self._log(SURVEY_LEVEL, msg, args, extra=extra_info, **kwargs)
 

--- a/app/src/orchestrator/call_handlers.py
+++ b/app/src/orchestrator/call_handlers.py
@@ -25,5 +25,5 @@ class LLMCallHandler:
         print("-----The Prompt-----")
         print(prompt)
         print("--------------------")
-        response, cb = self.model(prompt)
-        return prompt, response, cb
+        response, cost = self.model(prompt)
+        return prompt, response, cost

--- a/app/src/orchestrator/chat_orchestrator.py
+++ b/app/src/orchestrator/chat_orchestrator.py
@@ -126,10 +126,8 @@ class ChatOrchestrator(metaclass=SingletonMeta):
         # Retrieval use case
         # TODO: This is clunky - ideally we would have a LLM detect the intent for use cases
         #  involving user input.
-        if query[:7].lower() == "search:":
-            query = query[7:]
-            prompt = ContextRetrieval(prompt, self.config)
-        elif use_rag:
+        if query.lower().startswith("search:") or use_rag:
+            query = query[7:] if query.lower().startswith("search:") else query
             prompt = ContextRetrieval(prompt, self.config)
 
         # look for moderation filter
@@ -139,7 +137,7 @@ class ChatOrchestrator(metaclass=SingletonMeta):
         # look for only use context
         if query_config.onlyusecontext:
             prompt = OnlyUseContextDecorator(prompt)
-            
+
         if query_config.useknowledgebase:
             prompt = ContextRetrieval(prompt, self.config, collection="user")
 

--- a/app/src/orchestrator/chat_orchestrator.py
+++ b/app/src/orchestrator/chat_orchestrator.py
@@ -1,5 +1,6 @@
 import os
 
+import requests
 import toml
 from logs.logger import logger
 from orchestrator.call_handlers import LLMCallHandler
@@ -12,6 +13,7 @@ from orchestrator.utils import (
 from prompt.base_prompt import ConcretePrompt
 from prompt.prompts import ModerationDecorator, OnlyUseContextDecorator
 from prompt.retrieval import ContextRetrieval
+from requests.exceptions import ConnectTimeout
 
 from models.models import LocalAIModel, OpenAIChatModel
 
@@ -139,16 +141,25 @@ class ChatOrchestrator(metaclass=SingletonMeta):
         if query_config.onlyusecontext:
             prompt = OnlyUseContextDecorator(prompt)
 
-        handler = LLMCallHandler(self.model, prompt, self.config)
+        try:
+            handler = LLMCallHandler(self.model, prompt, self.config)
+            new_query, query_rewrite_cost = self.rewrite_query(query)
+            llm_prompt, response, cost = handler.call_llm(new_query)
 
-        new_query, query_rewrite_cost = self.rewrite_query(query)
-        llm_prompt, response, cost = handler.call_llm(new_query)
+        # Carter: we will want a better solution here but we need error handling for the time being.
+        # This catches errors when the local models are offline
+        except ConnectTimeout:
+            logger.error("Unable to connect to local model.")
+            return "N/A", "The model you selected is not online.", 0.0
 
         return llm_prompt, response, cost + query_rewrite_cost
 
     def rewrite_query(self, query: str):
-        """Reformats the user query for improved search results"""
-        return self.model(DEFAULT_QUERY_REWRITER.format(question=query))
+        """Reformats the user query for improved search results."""
+        return self.model(
+            DEFAULT_QUERY_REWRITER.format(question=query),
+            override_config={"temperature": 0.0},
+        )
 
     def query(self, prompt):
         response, cb = self.model(prompt)

--- a/app/src/orchestrator/config.py
+++ b/app/src/orchestrator/config.py
@@ -1,6 +1,6 @@
 from typing import Literal, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class ModelParams(BaseModel):
@@ -42,6 +42,7 @@ class RAGParams(BaseModel):
 
 
 class SystemConfig(BaseModel):
+    model_config = ConfigDict(protected_namespaces=())
     model_name: str
     model_params: ModelParams
     model_auth: ModelAuth

--- a/app/src/orchestrator/utils.py
+++ b/app/src/orchestrator/utils.py
@@ -11,38 +11,33 @@ DEFAULT_SYSTEM_PROMPT: str = """ You are a helpful chatbot that answers question
 
 
 DEFAULT_QUERY_REWRITER: str = """
-    You are an expert in search queries for scientific literature review. 
-    Your task is to simplify verbose and detailed user queries into concise and effective queries for information retrieval. 
-    Focus on capturing the essential scientific keywords relevant to toxicology or pesticide research.
+    You are an expert in simplifying scientific literature search queries for toxicology and pesticide research. 
+    Your task is to rewrite verbose and detailed user queries into concise, focused search queries that retain only the most relevant scientific keywords.
 
-    Here are examples of the queries that need simplification, and what the simplification should look like:
+    Here are some examples to guide you:
 
     Example 1:
     Verbose Query: What is the acceptable daily intake of glyphosate for humans?
-    Is simplification needed here: Yes.
     Simplified Query: Glyphosate acceptable daily intake humans
 
     Example 2:
     Verbose Query: What are the reproductive parameters evaluated in OECD TG 408?
-    Is simplification needed here: Yes.
     Simplified Query: Reproductive parameters OECD TG 408
 
     Example 3:
     Verbose Query: malathion and glyphosate monograph differences.
-    Is simplification needed here: No.
     Simplified Query: malathion and glyphosate monograph differences
 
     Example 4:
     Verbose Query: Tell me what studies say about aquatic ecotoxicology of triticonazole
-    Is simplification needed here: Yes.
     Simplified Query: triticonazole aquatic ecotoxicology
 
-    This is the user query:
+    Your task is to process the following query:
+
     {question}
 
-    Do not output anything except the simplified query. Do not output the words 'simplified query' or anything else.
-    If the query is already simple enough just return the original user question.
-    Only output the simplified query, nothing else! 
+    Return only the simplified query. If the query is already sufficiently concise, return it exactly as it is. 
+    Do not include any additional text or labels such as "Original Query" or "Simplified Query"—only output the simplified query itself.
 """
 
 

--- a/app/src/orchestrator/utils.py
+++ b/app/src/orchestrator/utils.py
@@ -19,28 +19,28 @@ DEFAULT_QUERY_REWRITER: str = """
 
     Example 1:
     Verbose Query: What is the acceptable daily intake of glyphosate for humans?
-    Is simplification needed her: Yes.
+    Is simplification needed here: Yes.
     Simplified Query: Glyphosate acceptable daily intake humans
 
     Example 2:
     Verbose Query: What are the reproductive parameters evaluated in OECD TG 408?
-    Is simplification needed her: Yes.
+    Is simplification needed here: Yes.
     Simplified Query: Reproductive parameters OECD TG 408
 
     Example 3:
     Verbose Query: malathion and glyphosate monograph differences.
-    Is simplification needed her: No.
+    Is simplification needed here: No.
     Simplified Query: malathion and glyphosate monograph differences
 
     Example 4:
     Verbose Query: Tell me what studies say about aquatic ecotoxicology of triticonazole
-    Is simplification needed her: Yes.
+    Is simplification needed here: Yes.
     Simplified Query: triticonazole aquatic ecotoxicology
 
     This is the user query:
     {question}
 
-    Do not output anything except the simplified query. 
+    Do not output anything except the simplified query. Do not output the words 'simplified query' or anything else.
     If the query is already simple enough just return the original user question.
     Only output the simplified query, nothing else! 
 """

--- a/app/src/orchestrator/utils.py
+++ b/app/src/orchestrator/utils.py
@@ -1,6 +1,50 @@
 import hydra
 from omegaconf import DictConfig
 
+DEFAULT_SYSTEM_PROMPT: str = """ You are a helpful chatbot that answers questions from the perspective 
+    of a regulatory toxicologist. You should answer the user's question in 
+    plain and precise language based on the below context. If the context 
+    doesn't contain any relevant information to the question, don't make 
+    something up. Instead, just say "I don't have information on that 
+    topic".
+    """
+
+
+DEFAULT_QUERY_REWRITER: str = """
+    You are an expert in search queries for scientific literature review. 
+    Your task is to simplify verbose and detailed user queries into concise and effective queries for information retrieval. 
+    Focus on capturing the essential scientific keywords relevant to toxicology or pesticide research.
+
+    Here are examples of the queries that need simplification, and what the simplification should look like:
+
+    Example 1:
+    Verbose Query: What is the acceptable daily intake of glyphosate for humans?
+    Is simplification needed her: Yes.
+    Simplified Query: Glyphosate acceptable daily intake humans
+
+    Example 2:
+    Verbose Query: What are the reproductive parameters evaluated in OECD TG 408?
+    Is simplification needed her: Yes.
+    Simplified Query: Reproductive parameters OECD TG 408
+
+    Example 3:
+    Verbose Query: malathion and glyphosate monograph differences.
+    Is simplification needed her: No.
+    Simplified Query: malathion and glyphosate monograph differences
+
+    Example 4:
+    Verbose Query: Tell me what studies say about aquatic ecotoxicology of triticonazole
+    Is simplification needed her: Yes.
+    Simplified Query: triticonazole aquatic ecotoxicology
+
+    This is the user query:
+    {question}
+
+    Do not output anything except the simplified query. 
+    If the query is already simple enough just return the original user question.
+    Only output the simplified query, nothing else! 
+"""
+
 
 def load_config(config_name: str, config_dir: str):
     """

--- a/app/src/prompt/retrieval.py
+++ b/app/src/prompt/retrieval.py
@@ -50,7 +50,6 @@ class ContextRetrieval(PromptDecorator):
             [query], top_k=top_k, collection=self.collection
         )
 
-        print(results)
         #### If no results found, we should log and we should also tell the user that their RAG search did not return any results for some reason
         if not results or len(results[0]) == 0:
             # No results found; handle the case here
@@ -58,7 +57,12 @@ class ContextRetrieval(PromptDecorator):
             print("no results returned...")
 
         print(results)
-        context_text = "\n\n---\n\n".join([res.document for res in results[0]])
+        context_text = "\n\n---\n\n".join(
+            [
+                f"Context Source: {res.id}\nDocument: {res.document}"
+                for res in results[0]
+            ]
+        )
         return self._prompt.get_prompt(query).format(
             decorate=self.PromptTemplate.format(
                 context=context_text, decorate="{decorate}"

--- a/app/src/prompt/retrieval.py
+++ b/app/src/prompt/retrieval.py
@@ -2,7 +2,6 @@ import os
 
 from langchain_community.vectorstores import Chroma
 from orchestrator.config import SystemConfig
-from orchestrator.utils import load_config
 from prompt.base_prompt import PromptComponent, PromptDecorator
 
 from data_broker.data_broker import DataBroker


### PR DESCRIPTION
- fixed logging user bug
- error handling for Ollama embedder when macbook is offline
- fixed pydantic warnings
- error handling for models when macbook is offline
- added option to modify model params when making calls without changing model configs (think of the case where we want to reformat the query, temperature should be set to 0.0 regardless of the config values)
- query rewriter (this is functional, however we need to rethink the way we do some of the PromptComponent wrapper classes like ContextRetrieval).