### PR TITLE
Milvus version update patch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,12 @@ FROM python:3.10-slim
 WORKDIR /usr/src/
 
 COPY ./requirements.txt .
-RUN pip install --upgrade pip
-RUN pip install --no-cache-dir -r requirements.txt
+ARG UPDATE_DEPS=false
+RUN if [ "$UPDATE_DEPS" = "true" ]; then \
+        pip install --upgrade -r requirements.txt; \
+    else \
+        pip install -r requirements.txt; \
+    fi
 
 WORKDIR /usr/src/data/
 COPY ./app/data .

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ streamlit run auth.py
 ```
 
 ## Running the full app via docker compose
+This is necessary to run with Milvus.
 ```
 ./run_science_gpt.sh
 ```
@@ -23,9 +24,14 @@ To bypass authentication for dev purposes run
 ./run_science_gpt.sh --dev
 ```
 
-And to rebuild the images run
+To rebuild the images run
 ```
 ./run_science_gpt.sh --build
 ```
 
-The --build and --dev flags can be used together.
+To update dependencies run
+```
+./run_science_gpt.sh --update-deps
+```
+
+The --dev, --build, and --update-deps flags can be used together.

--- a/app/src/configs/system_config.yaml
+++ b/app/src/configs/system_config.yaml
@@ -21,7 +21,7 @@ chunking:
   method: "recursive_character"
 
 embedding:
-  model: "all-mpnet-base-v2"
+  model: "mxbai-embed-large"
 
 vector_db:
   type: "milvus"

--- a/app/src/configs/system_config.yaml
+++ b/app/src/configs/system_config.yaml
@@ -21,7 +21,7 @@ chunking:
   method: "recursive_character"
 
 embedding:
-  model: "mxbai-embed-large"
+  model: "all-mpnet-base-v2"
 
 vector_db:
   type: "milvus"

--- a/app/src/ingestion/vectordb.py
+++ b/app/src/ingestion/vectordb.py
@@ -261,6 +261,7 @@ class MilvusDB(VectorDB):
             )
 
             index_params = self.client.prepare_index_params()
+            # TODO allow user to change the index parameters
             index_params.add_index(
                 field_name="vector", index_type="AUTOINDEX", metric_type="COSINE"
             )
@@ -297,6 +298,7 @@ class MilvusDB(VectorDB):
         """
         Search for similar vectors in the database with optional keyword filtering.
         """
+        # TODO allow user to set the search params
         search_params = {"metric_type": "COSINE", "params": {"nprobe": 10}}
 
         filter_expr = (

--- a/app/src/ingestion/vectordb.py
+++ b/app/src/ingestion/vectordb.py
@@ -300,7 +300,7 @@ class MilvusDB(VectorDB):
         search_params = {"metric_type": "COSINE", "params": {"nprobe": 10}}
 
         filter_expr = (
-            f"TEXT_MATCH(document, {' '.join(keywords)})" if keywords else None
+            f"TEXT_MATCH(document, '{' '.join(keywords)}')" if keywords else None
         )
 
         results = self.client.search(

--- a/app/src/tests/databroker/test_databroker.py
+++ b/app/src/tests/databroker/test_databroker.py
@@ -53,7 +53,7 @@ def databroker_instance(mock_database_config, secrets_path, vector_store_type):
     return DataBroker(config, secrets_path)
 
 
-@pytest.mark.parametrize("vector_store_type", ["milvus", "chromadb"])
+@pytest.mark.parametrize("vector_store_type", ["milvus"])
 class TestDataBroker:
     def test_singleton_pattern(
         self, mock_database_config, secrets_path, vector_store_type
@@ -72,26 +72,26 @@ class TestDataBroker:
         assert hasattr(databroker_instance, "extractors")
         assert hasattr(databroker_instance, "vectorstore")
 
+    def test_search_and_keyword_functionality(self, databroker_instance):
+        """Tests search and keyword functionality"""
+        search_results = databroker_instance.search(
+            queries=["some random text"],
+            collection="base",
+            top_k=1,
+        )
+        assert len(search_results[0]) == 1
+        search_results = databroker_instance.search(
+            queries=["some random text"],
+            collection="base",
+            top_k=1,
+            # choose a keyword that does not appear in the document
+            keywords=["jpoimvase"],
+        )
+        assert len(search_results[0]) == 0
+
     def test_clear_functionality(self, databroker_instance):
         """Test clear functionality"""
         assert databroker_instance.vectorstore["base"].get_all_ids() != []
         databroker_instance.vectorstore["base"].clear()
         time.sleep(3)  # wait to avoid race conditions
         assert databroker_instance.vectorstore["base"].get_all_ids() == []
-
-    def test_search_functionality(self, databroker_instance):
-        """Tests search functionality"""
-        search_results = databroker_instance.search(
-            queries=["some random text"], collection="base", top_k=1
-        )
-        assert len(search_results) == 1
-
-    def test_keyword_functionality(self, databroker_instance):
-        """Tests search functionality"""
-        search_results = databroker_instance.search(
-            queries=["some random text"],
-            collection="base",
-            top_k=1,
-            keywords=["list", "of", "keywords"],
-        )
-        # assert len(search_results) == 1

--- a/app/src/tests/databroker/test_databroker.py
+++ b/app/src/tests/databroker/test_databroker.py
@@ -85,3 +85,13 @@ class TestDataBroker:
             queries=["some random text"], collection="base", top_k=1
         )
         assert len(search_results) == 1
+
+    def test_keyword_functionality(self, databroker_instance):
+        """Tests search functionality"""
+        search_results = databroker_instance.search(
+            queries=["some random text"],
+            collection="base",
+            top_k=1,
+            keywords=["list", "of", "keywords"],
+        )
+        # assert len(search_results) == 1

--- a/app/src/tests/databroker/test_databroker.py
+++ b/app/src/tests/databroker/test_databroker.py
@@ -53,7 +53,7 @@ def databroker_instance(mock_database_config, secrets_path, vector_store_type):
     return DataBroker(config, secrets_path)
 
 
-@pytest.mark.parametrize("vector_store_type", ["milvus"])
+@pytest.mark.parametrize("vector_store_type", ["milvus", "chromadb"])
 class TestDataBroker:
     def test_singleton_pattern(
         self, mock_database_config, secrets_path, vector_store_type

--- a/docker-compose-sciencegpt.yaml
+++ b/docker-compose-sciencegpt.yaml
@@ -3,6 +3,8 @@ services:
     container_name: science-gpt-app
     build:
       context: ./
+      args:
+        - UPDATE_DEPS=${UPDATE_DEPS:-false}
     expose:
       - "8501"
     volumes:

--- a/run_science_gpt.sh
+++ b/run_science_gpt.sh
@@ -2,6 +2,7 @@ mkdir ./app/data # dir must exist for dockerfile
 
 DEV_MODE=false
 BUILD=false
+UPDATE_DEPS=false
 
 # Parse arguments
 for arg in "$@"
@@ -13,15 +14,18 @@ do
         --build)
         BUILD=true
         ;;
+        --update-deps)
+        UPDATE_DEPS=true
+        ;;
     esac
 done
 
 if [ "$DEV_MODE" = true ] && [ "$BUILD" = true ]; then
-    DEV_MODE=true docker compose -f docker-compose-sciencegpt.yaml -f docker-compose-milvus.yaml up --pull always --build
+    DEV_MODE=true UPDATE_DEPS=$UPDATE_DEPS docker compose -f docker-compose-sciencegpt.yaml -f docker-compose-milvus.yaml up --pull always --build
 elif [ "$DEV_MODE" = true ]; then
     DEV_MODE=true docker compose -f docker-compose-sciencegpt.yaml -f docker-compose-milvus.yaml up --pull always
 elif [ "$BUILD" = true ]; then
-    docker compose -f docker-compose-sciencegpt.yaml -f docker-compose-milvus.yaml up --pull always --build
+    UPDATE_DEPS=$UPDATE_DEPS docker compose -f docker-compose-sciencegpt.yaml -f docker-compose-milvus.yaml up --pull always --build
 else
     docker compose -f docker-compose-sciencegpt.yaml -f docker-compose-milvus.yaml up --pull always
 fi


### PR DESCRIPTION
In the previous [PR](https://github.com/science-gpt/science-gpt/pull/64) to add keyword support to Milvus, I updated the milvus version 2.5, however, i forgot to update it's python sdk (pymilvus) to also match the 2.5 version. I also forgot to include quotations around the TEXT_MATCH clause. These bugs were caught by @spencer-crook.

In addition to fixing the two problems above, ive made two other changes:

- Added an "--update-deps" param that can be used to run pip update.
- Added a keyword search test in the databroker pytest suite.