### PR TITLE
Docling Chunking and Extraction

### DIFF
--- a/app/src/configs/system_config.yaml
+++ b/app/src/configs/system_config.yaml
@@ -66,13 +66,14 @@ extraction:
   extraction_method: "pypdf2"
   supported_extractors:
     - "pypdf2"
-    - "pymupdf"
-    - "pymypdf4llm"
+    - "docling"
   
 
 chunking:
   chunking_method: "recursive_character"
   supported_chunkers:
+    - "docling_hierarchical"
+    - "split_sentences"
     - "recursive_character"
     - "recursive_character:large_chunks"
     - "recursive_character:small_chunks"
@@ -88,7 +89,7 @@ embedding:
 
 # Database Options
 vector_db:
-  database: "chromadb"
+  database: "milvus"
   host: "standalone"
   port: 19530
   supported_databases:

--- a/app/src/databroker/databroker.py
+++ b/app/src/databroker/databroker.py
@@ -13,7 +13,7 @@ from ingestion.chunking import (
     SplitSentencesChunker,
 )
 from ingestion.embedding import Embedder, HuggingFaceEmbedder, OllamaEmbedder
-from ingestion.extraction import DoclingExtract, PDFData, PyPDF2Extract, TextExtract
+from ingestion.extraction import DoclingPDFExtract, PDFData, PyPDF2Extract, TextExtract
 from ingestion.raw_data import Data
 from ingestion.vectordb import ChromaDB, MilvusDB, SearchResult, VectorDB
 from orchestrator.utils import SingletonMeta
@@ -142,7 +142,7 @@ class DataBroker(metaclass=SingletonMeta):
         if self._database_config.pdf_extractor.extraction_method == "pypdf2":
             extractors["pdf"] = PyPDF2Extract()
         elif self._database_config.pdf_extractor.extraction_method == "docling":
-            extractors["pdf"] = DoclingExtract()
+            extractors["pdf"] = DoclingPDFExtract()
         return extractors
 
     def _create_vectorstore(self, embedding_dimension: int) -> Dict[str, VectorDB]:

--- a/app/src/databroker/databroker.py
+++ b/app/src/databroker/databroker.py
@@ -13,7 +13,12 @@ from ingestion.chunking import (
     SplitSentencesChunker,
 )
 from ingestion.embedding import Embedder, HuggingFaceEmbedder, OllamaEmbedder
-from ingestion.extraction import DoclingPDFExtract, PDFData, PyPDF2Extract, TextExtract
+from ingestion.extraction import (
+    ContentExtractor,
+    DoclingPDFExtract,
+    PDFData,
+    PyPDF2Extract,
+)
 from ingestion.raw_data import Data
 from ingestion.vectordb import ChromaDB, MilvusDB, SearchResult, VectorDB
 from orchestrator.utils import SingletonMeta
@@ -130,13 +135,13 @@ class DataBroker(metaclass=SingletonMeta):
             )
         return chunker
 
-    def _create_extractors(self) -> Dict[str, TextExtract]:
+    def _create_extractors(self) -> Dict[str, ContentExtractor]:
         """
         Creates a dictionary of extractors for different data types.
         Each of the supported data types receives its own extractor.
         Extractors are set using the config.
         Returns:
-            Dict[str, TextExtract]: A dictionary mapping data types to their respective extractors
+            Dict[str, ContentExtractor]: A dictionary mapping data types to their respective extractors
         """
         extractors = {}
         if self._database_config.pdf_extractor.extraction_method == "pypdf2":

--- a/app/src/ingestion/chunking.py
+++ b/app/src/ingestion/chunking.py
@@ -127,30 +127,3 @@ class DoclingHierarchicalChunker(Chunker):
             for i, chunk in tqdm(enumerate(chunks_iter))
         ]
         return chunks
-
-
-"""
-# how hybdrid chunker could be implemented.
-class DoclingHybridChunker(Chunker):
-    def __init__(self):
-        self.chunker = HybridChunker()
-    
-    def __call__(self, content: DoclingDocument) -> List[Chunk]:
-        if not isinstance(content, DoclingDocument):
-            raise TypeError(
-                f"DoclingHybridChunker requires DoclingDocument input, but got {type(content)}. "
-                "Use DoclingExtract or a different chunker."
-            )
-        chunks_iter = self.chunker.chunk(content.conv_result.document)
-        chunks = [
-            Chunk(
-                text=chunk.text,
-                name=f"{content.name} - Chunk {i+1}",
-                data_type=content.data_type,
-            )
-            for i, chunk in tqdm(enumerate(chunks_iter))
-        ]
-        return chunks
-"""
-# TODO: provide a way to configure the docling extraction and chunking methods
-# TODO: update the config files

--- a/app/src/ingestion/chunking.py
+++ b/app/src/ingestion/chunking.py
@@ -3,11 +3,12 @@ from dataclasses import dataclass
 from typing import List
 
 import nltk
+from docling.chunking import HierarchicalChunker
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 from nltk.tokenize import sent_tokenize
 from tqdm import tqdm
 
-from .extraction import Text
+from .extraction import DoclingDocument, ExtractedContent
 from .raw_data import Data
 
 
@@ -34,12 +35,12 @@ class Chunker(ABC):
     """
 
     @abstractmethod
-    def __call__(self, text: Text) -> List[Chunk]:
+    def __call__(self, content: ExtractedContent) -> List[Chunk]:
         """
-        Split the given text into chunks.
+        Split the given content into chunks.
 
         Args:
-            text (Text): The text to be split into chunks.
+            content (ExtractedContent): The content to be split into chunks.
 
         Returns:
             List[Chunk]: A list of Chunk objects representing the split text.
@@ -58,22 +59,23 @@ class SplitSentencesChunker(Chunker):
         """
         nltk.download("punkt_tab", quiet=True)
 
-    def __call__(self, text: Text) -> List[Chunk]:
+    def __call__(self, content: ExtractedContent) -> List[Chunk]:
         """
-        Split the given text into chunks, where each chunk is a sentence.
+        Split the given content into chunks, where each chunk is a sentence.
 
         Args:
-            text (Text): The text to be split into chunks.
+            content (ExtractedContent): The content to be split into chunks.
 
         Returns:
             List[Chunk]: A list of Chunk objects, each containing a single sentence.
         """
-        sentences = sent_tokenize(text.text)
+        text = content.get_text()
+        sentences = sent_tokenize(text)
         return [
             Chunk(
                 text=sentence,
-                name=f"{text.name} - Sentence {i+1}",
-                data_type=text.data_type,
+                name=f"{content.name} - Sentence {i+1}",
+                data_type=content.data_type,
             )
             for i, sentence in enumerate(sentences)
         ]
@@ -88,13 +90,67 @@ class RecursiveCharacterChunker(Chunker):
             is_separator_regex=is_separator_regex,
         )
 
-    def __call__(self, text: Text) -> List[Chunk]:
-        chunks = self.text_splitter.split_text(text.text)
+    def __call__(self, content: ExtractedContent) -> List[Chunk]:
+        text = content.get_text()
+        chunks = self.text_splitter.split_text(text)
         return [
             Chunk(
                 text=c,
-                name=f"{text.name} - Chunk {i+1}",
-                data_type=text.data_type,
+                name=f"{content.name} - Chunk {i+1}",
+                data_type=content.data_type,
             )
             for i, c in tqdm(enumerate(chunks))
         ]
+
+
+class DoclingHierarchicalChunker(Chunker):
+    """
+    A Chunker implementation that uses Docling's HierarchicalChunker to split a DoclingDocument into chunks.
+    """
+
+    def __init__(self):
+        self.chunker = HierarchicalChunker()
+
+    def __call__(self, content: DoclingDocument) -> List[Chunk]:
+        if not isinstance(content, DoclingDocument):
+            raise TypeError(
+                f"DoclingChunker requires DoclingDocument input, but got {type(content)}. "
+                "Use DoclingExtract or a different chunker."
+            )
+        chunks_iter = self.chunker.chunk(content.conv_result.document)
+        chunks = [
+            Chunk(
+                text=chunk.text,
+                name=f"{content.name} - Chunk {i+1}",
+                data_type=content.data_type,
+            )
+            for i, chunk in tqdm(enumerate(chunks_iter))
+        ]
+        return chunks
+
+
+"""
+# how hybdrid chunker could be implemented.
+class DoclingHybridChunker(Chunker):
+    def __init__(self):
+        self.chunker = HybridChunker()
+    
+    def __call__(self, content: DoclingDocument) -> List[Chunk]:
+        if not isinstance(content, DoclingDocument):
+            raise TypeError(
+                f"DoclingHybridChunker requires DoclingDocument input, but got {type(content)}. "
+                "Use DoclingExtract or a different chunker."
+            )
+        chunks_iter = self.chunker.chunk(content.conv_result.document)
+        chunks = [
+            Chunk(
+                text=chunk.text,
+                name=f"{content.name} - Chunk {i+1}",
+                data_type=content.data_type,
+            )
+            for i, chunk in tqdm(enumerate(chunks_iter))
+        ]
+        return chunks
+"""
+# TODO: provide a way to configure the docling extraction and chunking methods
+# TODO: update the config files

--- a/app/src/ingestion/chunking.py
+++ b/app/src/ingestion/chunking.py
@@ -109,9 +109,21 @@ class DoclingHierarchicalChunker(Chunker):
     """
 
     def __init__(self):
+        """
+        Initialize the DoclingHierarchicalChunker.
+        """
         self.chunker = HierarchicalChunker()
 
     def __call__(self, content: DoclingDocument) -> List[Chunk]:
+        """
+        Split the given content into chunks, where each chunk is a sentence.
+
+        Args:
+            content (ExtractedContent): The content to be split into chunks.
+
+        Returns:
+            List[Chunk]: A list of Chunk objects.
+        """
         if not isinstance(content, DoclingDocument):
             raise TypeError(
                 f"DoclingChunker requires DoclingDocument input, but got {type(content)}. "

--- a/app/src/orchestrator/call_handlers.py
+++ b/app/src/orchestrator/call_handlers.py
@@ -1,7 +1,6 @@
+from models.models import ChatModel
 from orchestrator.config import SystemConfig
 from prompt.base_prompt import PromptComponent
-
-from models.models import ChatModel
 
 
 class LLMCallHandler:

--- a/app/src/orchestrator/chat_orchestrator.py
+++ b/app/src/orchestrator/chat_orchestrator.py
@@ -2,6 +2,7 @@ import os
 
 import toml
 from logs.logger import logger
+from models.models import LocalAIModel, OpenAIChatModel
 from orchestrator.call_handlers import LLMCallHandler
 from orchestrator.config import SystemConfig
 from orchestrator.utils import DEFAULT_SYSTEM_PROMPT, SingletonMeta, load_config
@@ -9,8 +10,6 @@ from prompt.base_prompt import ConcretePrompt
 from prompt.prompts import ModerationDecorator, OnlyUseContextDecorator
 from prompt.retrieval import ContextRetrieval
 from requests.exceptions import ConnectTimeout
-
-from models.models import LocalAIModel, OpenAIChatModel
 
 
 class ChatOrchestrator(metaclass=SingletonMeta):

--- a/app/src/prompt/retrieval.py
+++ b/app/src/prompt/retrieval.py
@@ -1,8 +1,7 @@
 from databroker.databroker import DataBroker
+from models.models import ChatModel
 from orchestrator.config import SystemConfig
 from prompt.base_prompt import PromptComponent, PromptDecorator
-
-from models.models import ChatModel
 
 DEFAULT_QUERY_REWRITER: str = """
     You are an expert in simplifying scientific literature search queries for toxicology and pesticide research. 

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ ChromaDB
 pymilvus
 numpy
 pytest
+docling


### PR DESCRIPTION
- Added docling chunker and extractor
- Refactored the way extractors and chunkers interact. Previously, extractor outputs a text object containing the extracted text as a string, then the chunkers take these text objects and chunk the string. Now, the extractors output `ExtractedContent` which contains the extracted content (could be string or a docling document). Then the chunkers take these `ExtractedContent` objects and convert them into chunks.
- Docling chunker requires docling extraction (databroker and chunker will throw error if thats not the case). Docling extraction followed by basic chunking will throw a warning but no error.
- Cleaned up the system config a bit
- Linted the codebase