### PR TITLE
Fix Sparse Vector Generation and MilvusDB Insert/Search Function Integration

### DIFF
--- a/app/src/ingestion/embedding.py
+++ b/app/src/ingestion/embedding.py
@@ -210,10 +210,10 @@ class BGEM3Embedder(Embedder):
     def get_sparse_vector(self, docs: List[str]):
         """
         Get sparse vectors for the given documents using the existing embedder.
-        
+
         Args:
             docs (List[str]): List of document texts.
-            
+
         Returns:
             List of sparse vectors in Milvus format without changing the type to list.
         """

--- a/app/src/ingestion/embedding.py
+++ b/app/src/ingestion/embedding.py
@@ -207,6 +207,20 @@ class BGEM3Embedder(Embedder):
         )
         self.embedding_dimension = self.embedder.dim["dense"]
 
+    def get_sparse_vector(self, docs: List[str]):
+        """
+        Get sparse vectors for the given documents using the existing embedder.
+        
+        Args:
+            docs (List[str]): List of document texts.
+            
+        Returns:
+            List of sparse vectors in Milvus format without changing the type to list.
+        """
+        sparse_embeddings = self.embedder(docs)
+        sparse_vectors = sparse_embeddings["sparse"]
+        return sparse_vectors
+
     def __call__(self, chunks: List[Chunk]) -> List[Embedding]:
         """
         Embed a list of text chunks using the BGEM3 model (both dense & sparse).
@@ -229,7 +243,6 @@ class BGEM3Embedder(Embedder):
                 data_type=chunk.data_type,
                 docs=chunk.text,
                 dense_vector=docs_embeddings["dense"][i],
-                sparse_vector=list(docs_embeddings["sparse"])[i],
             )
             for i, chunk in enumerate(chunks)
         ]

--- a/app/src/ingestion/vectordb.py
+++ b/app/src/ingestion/vectordb.py
@@ -261,7 +261,9 @@ class MilvusDB(VectorDB):
         self.dim = dense_dim
 
         self._setup_milvus()
-        self.sparse_embedder = BGEM3Embedder()  # Initialize the embedder for sparse vector
+        self.sparse_embedder = (
+            BGEM3Embedder()
+        )  # Initialize the embedder for sparse vector
 
     def _setup_milvus(self):
         self.client = MilvusClient(uri=f"http://{self.host}:{self.port}")
@@ -345,7 +347,9 @@ class MilvusDB(VectorDB):
                 "text": embedding.docs,
                 "filename": metadata["source"],
                 "dense_vector": embedding.dense_vector.tolist(),
-                "sparse_vector": self.sparse_embedder.get_sparse_vector([embedding.docs])
+                "sparse_vector": self.sparse_embedder.get_sparse_vector(
+                    [embedding.docs]
+                ),
             }
             for embedding, metadata in zip(embeddings, metadatum)
         ]
@@ -403,7 +407,10 @@ class MilvusDB(VectorDB):
             limit=top_k,
         )
         # get the sparse vector for query
-        query_sparse_vectors = [self.sparse_embedder.get_sparse_vector([embedding.docs]) for embedding in query_embeddings]
+        query_sparse_vectors = [
+            self.sparse_embedder.get_sparse_vector([embedding.docs])
+            for embedding in query_embeddings
+        ]
         sparse_req = AnnSearchRequest(
             query_sparse_vectors,
             "sparse_vector",


### PR DESCRIPTION
Converting sparse vectors to lists before passing them to MilvusDB was causing issues. 
To resolve this, the get_sparse_vector function should be called directly within vectorDB without performing any manual conversions. 
This ensures proper handling of sparse vectors and prevents unexpected errors during insertion and search operations.